### PR TITLE
Fix #551

### DIFF
--- a/system/Base/BasePackage.php
+++ b/system/Base/BasePackage.php
@@ -1360,7 +1360,7 @@ abstract class BasePackage extends Controller
 		return $data;
 	}
 
-	public function remove(int $id, $resetCache = true, $removeRelated = true, $removeRelatedAliases = [])
+	public function remove(int $id, $resetCache = true, $removeRelated = true, $excludeRelatedAliases = [])
 	{
 		$this->getFirst('id', $id);
 
@@ -1380,17 +1380,13 @@ abstract class BasePackage extends Controller
 						$type = $modelRelation['relationObj']->getType();
 
 						if ($type !== 0) {//Other than belongsTo
-							$removeAlias = false;
-
 							$alias = $modelRelation['relationObj']->getOption('alias');
 
-							if (count($removeRelatedAliases) > 0 && in_array($alias, $removeRelatedAliases)) {
-								$removeAlias = true;
-							} else if (count($removeRelatedAliases) === 0) {
-								$removeAlias = true;
+							if (count($excludeRelatedAliases) > 0 && in_array($alias, $excludeRelatedAliases)) {
+								continue;
 							}
 
-							if ($removeAlias && $this->model->{$alias}) {
+							if ($this->model->{$alias}) {
 								$relationRowsData = $this->model->{$alias}->toArray();
 
 								if (!$this->model->{$alias}->delete()) {
@@ -1422,7 +1418,7 @@ abstract class BasePackage extends Controller
 				$this->addResponse("Could not delete " . ucfirst($this->packageNameS), 1);
 			}
 		} else if ($this->ffStore && $this->ffData && $this->ffData['id'] == $id) {
-			if ($this->ffStore->deleteById((int) $id, $removeRelated)) {
+			if ($this->ffStore->deleteById((int) $id, $removeRelated, $this->ffRelationsConditions, $excludeRelatedAliases)) {
 				$this->addResponse(ucfirst($this->packageNameS) . " Deleted!");
 
 				return true;

--- a/system/Base/Providers/DatabaseServiceProvider/Ff/Store.php
+++ b/system/Base/Providers/DatabaseServiceProvider/Ff/Store.php
@@ -714,63 +714,7 @@ class Store
                             continue;
                         }
 
-                        if ($relation[1] === 'hasOne' || $relation[1] === 'hasMany') {
-                            if ((in_array('hasParams', $relation) && $relationsConditions && count($relationsConditions) === 0) ||
-                                (in_array('hasParams', $relation) && $relationsConditions && count($relationsConditions) > 0 && !isset($relationsConditions[$relation[0]]))
-                            ) {
-                                throw new InvalidArgumentException('Model has params(conditions) set for ' . $relation[0] . '. Please set ffRelationsConditions. Please refer to model file.');
-                            }
-
-                            if (isset($relation[4])) {
-                                if (isset($relationsConditions[$relation[0]])) {
-                                    try {
-                                        $store = new Store($relation[2], $this->databasePath, $this->ff);
-
-                                        $storeDataArr = $store->findBy($relationsConditions[$relation[0]]);
-
-                                        if ($storeDataArr && is_array($storeDataArr) && count($storeDataArr) > 0) {
-                                            foreach ($storeDataArr as $storeData) {
-                                                if (isset($storeData['id'])) {
-                                                    $store->model = $relation[3];
-
-                                                    $store->deleteById((int) $storeData['id'], false);
-                                                }
-                                            }
-                                        }
-                                    } catch (\Exception $e) {
-                                        continue;
-                                    }
-                                } else {
-                                    $fields = explode(':', $relation[4]);
-
-                                    if (count($fields) > 0 && count($fields) % 2 == 0) {
-                                        $fieldsArr = $this->ff->helper->chunk($fields, 2);
-                                        $criteria = [];
-
-                                        foreach ($fieldsArr as $fieldArr) {
-                                            array_push($criteria, [$fieldArr[1], '=', $data[$fieldArr[0]]]);
-                                        }
-
-                                        try {
-                                            $store = new Store($relation[2], $this->databasePath, $this->ff);
-
-                                            $storeDataArr = $store->findBy($criteria);
-                                            if ($storeDataArr && is_array($storeDataArr) && count($storeDataArr) > 0) {
-                                                foreach ($storeDataArr as $storeData) {
-                                                    if (isset($storeData['id'])) {
-                                                        $store->model = $relation[3];
-
-                                                        $store->deleteById((int) $storeData['id'], false);
-                                                    }
-                                                }
-                                            }
-                                        } catch (\Exception $e) {
-                                            continue;
-                                        }
-                                    }
-                                }
-                            }
-                        } else if ($relation[1] === 'hasOneThrough' || $relation[1] === 'hasManyThrough') {
+                        if ($relation[1] === 'hasOneThrough' || $relation[1] === 'hasManyThrough') {
                             if (isset($relation[2]) && isset($relation[3])) {
                                 $relation[2] = explode('+', $relation[2]);
                                 $relation[3] = explode('+', $relation[3]);
@@ -834,6 +778,80 @@ class Store
                                     }
                                 } catch (\Exception $e) {
                                     continue;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            foreach ($schema['properties'] as $propertyKey => $property) {
+                if (!is_array($property['type'])) {
+                    continue;
+                }
+
+                if (in_array('array', $property['type']) && isset($property['relation'])) {
+                    $relation = explode('|', $property['relation']);
+
+                    if (count($relation) > 0) {
+                        if (in_array($relation[0], $exclude)) {
+                            continue;
+                        }
+
+                        if ($relation[1] === 'hasOne' || $relation[1] === 'hasMany') {
+                            if ((in_array('hasParams', $relation) && $relationsConditions && count($relationsConditions) === 0) ||
+                                (in_array('hasParams', $relation) && $relationsConditions && count($relationsConditions) > 0 && !isset($relationsConditions[$relation[0]]))
+                            ) {
+                                throw new InvalidArgumentException('Model has params(conditions) set for ' . $relation[0] . '. Please set ffRelationsConditions. Please refer to model file.');
+                            }
+
+                            if (isset($relation[4])) {
+                                if (isset($relationsConditions[$relation[0]])) {
+                                    try {
+                                        $store = new Store($relation[2], $this->databasePath, $this->ff);
+
+                                        $storeDataArr = $store->findBy($relationsConditions[$relation[0]]);
+
+                                        if ($storeDataArr && is_array($storeDataArr) && count($storeDataArr) > 0) {
+                                            foreach ($storeDataArr as $storeData) {
+                                                if (isset($storeData['id'])) {
+                                                    $store->model = $relation[3];
+
+                                                    $store->deleteById((int) $storeData['id'], false);
+                                                }
+                                            }
+                                        }
+                                    } catch (\Exception $e) {
+                                        continue;
+                                    }
+                                } else {
+                                    $fields = explode(':', $relation[4]);
+
+                                    if (count($fields) > 0 && count($fields) % 2 == 0) {
+                                        $fieldsArr = $this->ff->helper->chunk($fields, 2);
+                                        $criteria = [];
+
+                                        foreach ($fieldsArr as $fieldArr) {
+                                            array_push($criteria, [$fieldArr[1], '=', $data[$fieldArr[0]]]);
+                                        }
+
+                                        try {
+                                            $store = new Store($relation[2], $this->databasePath, $this->ff);
+
+                                            $storeDataArr = $store->findBy($criteria);
+                                            if ($storeDataArr && is_array($storeDataArr) && count($storeDataArr) > 0) {
+                                                foreach ($storeDataArr as $storeData) {
+                                                    if (isset($storeData['id'])) {
+                                                        $store->model = $relation[3];
+
+                                                        $store->deleteById((int) $storeData['id'], false);
+                                                    }
+                                                }
+                                            }
+                                        } catch (\Exception $e) {
+                                            continue;
+                                        }
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
- We need to loop through the intermediate models first as when we remove data from direct model, we can no longer check the intermediate data as the original ids are lost.
- Also, not all intermediate needs to be deleted, so added an exclusion to the remove method.